### PR TITLE
Add active class to dropdown item too

### DIFF
--- a/dynamic-menu.js
+++ b/dynamic-menu.js
@@ -38,7 +38,8 @@
         setActiveItem: function(hrefContext) {
             $(this.element)
                 .find('a[href="' + hrefContext + '"]')
-                .parent()
+                .addClass(this.settings.activeClass)
+                .parents('li')
                 .addClass(this.settings.activeClass);
         }
     });


### PR DESCRIPTION
If your navbar contains some dropdown menus, your script doesn't work with it.
With this update, dropdown menu is set to active and the link inside too.
(works on bootstrap 4, normally should works in v3)